### PR TITLE
Add gem version and build status badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # DBLock
 
+[![Gem Version](https://badge.fury.io/rb/db_lock.svg)](https://badge.fury.io/rb/db_lock)
+[![Build Status](https://travis-ci.org/mkon/db_lock.svg?branch=master)](https://travis-ci.org/mkon/db_lock)
+
 Gem to obtain and release manual db locks. This can be utilized for example to make sure that certain rake tasks do not run in parallel on the same database (for example when cron jobs run for too long or are accidentally started multiple times). Currently only supports:
 
 - MySQL


### PR DESCRIPTION
Adds the following badges to readme:

[![Gem Version](https://badge.fury.io/rb/db_lock.svg)](https://badge.fury.io/rb/db_lock)  [![Build Status](https://travis-ci.org/mkon/db_lock.svg?branch=master)](https://travis-ci.org/mkon/db_lock)